### PR TITLE
feat: Enable SDK tracking

### DIFF
--- a/src/connectors/Shopkit.js
+++ b/src/connectors/Shopkit.js
@@ -25,7 +25,8 @@ export default class Shopkit extends Component {
   }
 
   api = MoltinGateway({
-    client_id: this.props.clientId
+    client_id: this.props.clientId,
+    application: 'react-shopkit'
   })
 
   componentDidMount() {


### PR DESCRIPTION
Enable tracking via the JS SDK using the `application` header.